### PR TITLE
Improve Docker Mariadb usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sleep 30
 
 before_script:
-  - docker-compose exec ${DOCKER_SERVICE} sudo -u www-data drush site-install standard --db-url="mysql://drupal:drupal@db-${DOCKER_SERVICE}/drupal" --site-name=Example -y
+  - docker-compose exec ${DOCKER_SERVICE} sudo -u www-data drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
 
 script:
   - docker-compose exec ${DOCKER_SERVICE} sudo -u www-data -E ./vendor/bin/phpunit --group=template_whisperer

--- a/DEVELOPPING.md
+++ b/DEVELOPPING.md
@@ -38,7 +38,7 @@ Once run, you will be able to access to your fresh installed Drupal on `localhos
     docker-compose build --pull --build-arg DRUPAL_VERSION=8.9 [drupal-8|drupal-9]
     (get a coffee, this will take some time...)
     docker-compose up --build -d [drupal-8|drupal-9]
-    docker-compose exec [drupal-8|drupal-9] sudo -u www-data drush site-install standard --db-url='mysql://drupal:drupal@db-[drupal-8|drupal-9]/drupal' --site-name=Example -y
+    docker-compose exec [drupal-8|drupal-9] sudo -u www-data drush site-install standard --db-url='mysql://drupal:drupal@db/drupal' --site-name=Example -y
     
     # You may be interesed by reseting the admin passowrd of your Docker and install the module using those cmd.
     docker-compose exec [drupal-8|drupal-9] drush user:password admin admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,9 @@ services:
   drupal-8:
     build: ./docker/drupal-8
     depends_on:
-      - db-drupal-8
+      - db
     ports:
       - 8888:80
-    environment:
-      SIMPLETEST_DB: mysql://drupal:drupal@db-drupal-8/drupal
     volumes:
       # Mount the module Template Whisperer in the proper contrib module directory.
       - .:/var/www/html/modules/contrib/templates_whisperer
@@ -20,11 +18,9 @@ services:
   drupal-9:
     build: ./docker/drupal-9
     depends_on:
-      - db-drupal-9
+      - db
     ports:
-      - 8888:80
-    environment:
-      SIMPLETEST_DB: mysql://drupal:drupal@db-drupal-9/drupal
+      - 8889:80
     volumes:
       # Mount the module Template Whisperer in the proper contrib module directory.
       - .:/var/www/html/modules/contrib/templates_whisperer
@@ -32,16 +28,7 @@ services:
       - ./docker/phpunit.xml:/var/www/html/phpunit.xml
     restart: always
 
-  db-drupal-8:
-    image: mariadb:10.1
-    environment:
-      MYSQL_USER: drupal
-      MYSQL_PASSWORD: drupal
-      MYSQL_DATABASE: drupal
-      MYSQL_ROOT_PASSWORD: root
-    restart: always
-
-  db-drupal-9:
+  db:
     image: mariadb:10.3.7
     environment:
       MYSQL_USER: drupal


### PR DESCRIPTION
### 💬 Describe the pull request
Remove duplicate of MariaDB containers (version 10.1 & 10.3) to use the same mariadb:10.3.7 for both drupal-8 & drupal-9 container. 