### PR TITLE
Remove usage of sudo & build at runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 before_install:
   - docker-compose build --pull --build-arg DRUPAL_VERSION=${DRUPAL_VERSION} ${DOCKER_SERVICE}
-  - docker-compose up --build -d ${DOCKER_SERVICE}
+  - docker-compose up -d ${DOCKER_SERVICE}
   # wait on Docker to be ready, especially MariaDB that takes many seconds to be up.
   - sleep 30
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sleep 30
 
 before_script:
-  - docker-compose exec ${DOCKER_SERVICE} sudo -u www-data drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
+  - docker-compose exec -u www-data ${DOCKER_SERVICE} drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
 
 script:
-  - docker-compose exec ${DOCKER_SERVICE} sudo -u www-data -E ./vendor/bin/phpunit --group=template_whisperer
+  - docker-compose exec -u www-data ${DOCKER_SERVICE} phpunit --group=template_whisperer

--- a/docker/drupal-8/Dockerfile
+++ b/docker/drupal-8/Dockerfile
@@ -12,7 +12,6 @@ RUN set -eux; \
 		git \
 		zip \
 		unzip \
-		sudo \
 	;
 
 # Add Composer vendors directory to the path.

--- a/docker/drupal-9/Dockerfile
+++ b/docker/drupal-9/Dockerfile
@@ -12,7 +12,6 @@ RUN set -eux; \
 		git \
 		zip \
 		unzip \
-		sudo \
 	;
 
 # Add Composer vendors directory to the path.


### PR DESCRIPTION
### 💬 Describe the pull request
Remove usage of sudo and use docker argument instead to run tests under www-data user.

Also, remove build of the image when starting containers to avoid to build again the image without arguments (that result to test with wrong version of Drupal)