### PR TITLE
replace ^ by ~ when installing drupal/core-dev

### DIFF
--- a/docker/drupal-8/Dockerfile
+++ b/docker/drupal-8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
 
 # Install Drupal Dev dependencies such as PHPUnit, Behat-Mink, ...
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:^${DRUPAL_VERSION}
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:${DRUPAL_VERSION}
 
 # Install Drush.
 # Drush will be heavily use to setup a working Drupal environment.

--- a/docker/drupal-8/Dockerfile
+++ b/docker/drupal-8/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
 
 # Install Drupal Dev dependencies such as PHPUnit, Behat-Mink, ...
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:${DRUPAL_VERSION}
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:~${DRUPAL_VERSION}
 
 # Install Drush.
 # Drush will be heavily use to setup a working Drupal environment.


### PR DESCRIPTION
### 💬 Describe the pull request

replace `^` by `~` when installing `drupal/core-dev`

Otherwise, it may install `drupal:^8.9` when require specify `drupal:^8.8`

Example:

- https://jubianchi.github.io/semver-check/#/^8.8/8.9.0
- https://jubianchi.github.io/semver-check/#/~8.8/8.9.0 
