### PR TITLE
drop tests support on Drupal <= 9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         experimental: [ false ]
         include:
           - drupal_version: '11.0'
-            module: 'bamboo_twig'
+            module: 'template_whisperer'
             experimental: true
 
     steps:
@@ -48,7 +48,7 @@ jobs:
         experimental: [ false ]
         include:
           - drupal_version: '11.0'
-            module: 'bamboo_twig'
+            module: 'template_whisperer'
             experimental: true
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add coverage of Drupal 11.0-dev
 
 ### Removed
-- drop tests support on Drupal < 9.4
+- drop tests support on Drupal <= 9.4
 
 ## [4.0.0] - 2022-11-18
 ### Added

--- a/template_whisperer.info.yml
+++ b/template_whisperer.info.yml
@@ -1,7 +1,7 @@
 name: Template Whisperer
 type: module
 description: Provides a formalized way to declare and suggest page templates.
-core_version_requirement: ^9.3 || ^10 || ^11
+core_version_requirement: ^9.5 || ^10 || ^11
 package: Fields types
 
 dependencies:


### PR DESCRIPTION
### 💬 Description
drop tests support on Drupal <= 9.4

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
