### PR TITLE
fix tests for Drupal 10.3+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3']
         module: ['template_whisperer']
         experimental: [ false ]
         include:
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3']
         module: ['template_whisperer']
         experimental: [ false ]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - replace usage of user_role_names() deprecated in 10.2 and removed in 11.0
+- fix tests for Drupal 10.3 since twig template debug indicator of overiden themes changed from ascii to emojis
 
 ## [4.0.1] - 2024-03-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replace usage of user_role_names() deprecated in 10.2 and removed in 11.0
 - fix tests for Drupal 10.3 since twig template debug indicator of overiden themes changed from ascii to emojis
 - fix tests for Drupal 10.3 since changes on field creation experience
+- fix tests for Drupal 10.3 since changes on taxonomy form supporting vertical tabs
 
 ## [4.0.1] - 2024-03-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - replace usage of user_role_names() deprecated in 10.2 and removed in 11.0
 - fix tests for Drupal 10.3 since twig template debug indicator of overiden themes changed from ascii to emojis
+- fix tests for Drupal 10.3 since changes on field creation experience
 
 ## [4.0.1] - 2024-03-01
 ### Changed

--- a/tests/src/Functional/UiFieldTest.php
+++ b/tests/src/Functional/UiFieldTest.php
@@ -116,8 +116,9 @@ class UiFieldTest extends TemplateWhispererTestBase {
       $this->fillField('Add a new field', 'template_whisperer');
     }
 
-    // Since Drupal 11.0 The field label and machine_name are on another page.
-    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+    // Since Drupal 10.3 The field label and machine_name are on another page.
+    // @see https://www.drupal.org/project/drupal/issues/3346539
+    if (version_compare(\Drupal::VERSION, '10.3', '>=')) {
       $this->pressButton('Continue');
       $this->assertSession()->addressEquals('admin/structure/types/manage/article/fields/add-field');
     }

--- a/tests/src/Functional/UiFieldTest.php
+++ b/tests/src/Functional/UiFieldTest.php
@@ -276,15 +276,22 @@ class UiFieldTest extends TemplateWhispererTestBase {
     // Asserts the debug mode of twig is enabled.
     $this->assertTrue(strpos($output->getContent(), '<!-- THEME HOOK: \'node\' -->') !== FALSE);
 
+    // Since Drupal 10.3 the prefix has been changed for emojis.
+    // @see https://www.drupal.org/project/drupal/issues/3420709
+    $prefix = '* ';
+    if (version_compare(\Drupal::VERSION, '10.3', '>=')) {
+      $prefix = '▪️ ';
+    }
+
     // Asserts that all Page Template Whisperer based suggestions are present.
-    $this->assertTrue(strpos($output->getContent(), '* page--node--1--googlemap.html.twig') !== FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* page--node--googlemap.html.twig') !== FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}page--node--1--googlemap.html.twig") !== FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}page--node--googlemap.html.twig") !== FALSE);
 
     // Asserts that all Entity Template Whisperer based suggestions are present.
-    $this->assertTrue(strpos($output->getContent(), '* node--article--googlemap.html.twig') !== FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* node--1--article--googlemap.html.twig') !== FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* node--article--full--googlemap.html.twig') !== FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* node--1--article--full--googlemap.html.twig') !== FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--article--googlemap.html.twig") !== FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--1--article--googlemap.html.twig") !== FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--article--full--googlemap.html.twig") !== FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--1--article--full--googlemap.html.twig") !== FALSE);
   }
 
   /**
@@ -310,15 +317,22 @@ class UiFieldTest extends TemplateWhispererTestBase {
     // Asserts the debug mode of twig is enabled.
     $this->assertTrue(strpos($output->getContent(), '<!-- THEME HOOK: \'node\' -->') !== FALSE);
 
+    // Since Drupal 10.3 the prefix has been changed for emojis.
+    // @see https://www.drupal.org/project/drupal/issues/3420709
+    $prefix = '* ';
+    if (version_compare(\Drupal::VERSION, '10.3', '>=')) {
+      $prefix = '▪️ ';
+    }
+
     // Asserts that Page Template Whisperer based suggestions are not present.
-    $this->assertTrue(strpos($output->getContent(), '* page--node--1--googlemap.html.twig') === FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* page--node--googlemap.html.twig') === FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}page--node--1--googlemap.html.twig") === FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}page--node--googlemap.html.twig") === FALSE);
 
     // Asserts that Entity Template Whisperer based suggestions are not present.
-    $this->assertTrue(strpos($output->getContent(), '* node--article--googlemap.html.twig') === FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* node--1--article--googlemap.html.twig') === FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* node--article--full--googlemap.html.twig') === FALSE);
-    $this->assertTrue(strpos($output->getContent(), '* node--1--article--full--googlemap.html.twig') === FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--article--googlemap.html.twig") === FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--1--article--googlemap.html.twig") === FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--article--full--googlemap.html.twig") === FALSE);
+    $this->assertTrue(strpos($output->getContent(), "{$prefix}node--1--article--full--googlemap.html.twig") === FALSE);
   }
 
 }

--- a/tests/src/Functional/WidgetFormElementTest.php
+++ b/tests/src/Functional/WidgetFormElementTest.php
@@ -163,8 +163,8 @@ class WidgetFormElementTest extends TemplateWhispererTestBase {
     // Access the taxonomy term edit page.
     $this->drupalGet('taxonomy/term/' . $this->tag->id() . '/edit');
 
-    // Since Drupal 11.0 Taxonomy term form has been changed to support tabs.
-    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+    // Since Drupal 10.3 Taxonomy term form has been changed to support tabs.
+    if (version_compare(\Drupal::VERSION, '10.3', '>=')) {
       // Asserts the field is located on the Advanced Group - when possible.
       $this->assertSession()->elementExists('css', 'div[data-vertical-tabs-panes] #edit-field-template-whisperer-2-0 select');
     }


### PR DESCRIPTION
### 💬 Description
- fix tests for Drupal 10.3+ since twig template debug indicator of overiden themes changed from ascii to emojis
	- see https://www.drupal.org/project/drupal/issues/3420709
- fix tests for Drupal 10.3 since changes on field creation experience
	- see https://www.drupal.org/project/drupal/issues/3346539
- fix tests for Drupal 10.3 since changes on taxonomy form supporting vertical tabs

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
