### PR TITLE
remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - add official support of drupal 11.1
 
+### Changed
+- remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)
+
 ## [4.0.2] - 2024-08-09
 ### Added
 - add cpsell project words for Gitlab-CI

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
   <arg name="basepath" value="."/>
   <arg name="cache" value=".phpcs-cache"/>
   <arg name="colors"/>
-  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt"/>
+  <arg name="extensions" value="php,inc,module,install,info,test,profile,theme"/>
 
   <exclude-pattern>*\.(md|info\.yml)$</exclude-pattern>>
   <exclude-pattern>*/vendor/*</exclude-pattern>>


### PR DESCRIPTION
remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)