### PR TITLE
drop support of Drupal 9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['template_whisperer']
         experimental: [ false ]
         include:
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['template_whisperer']
         experimental: [ false ]
         include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,14 +32,12 @@ variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
   OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous & next minor (Drupal 10.0.x and 10.2.x).
+  # Opt in to testing previous minor (Drupal 11.0.13) & next minor (Drupal 11.2-dev).
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 9.5).
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 10.4.6).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # The 4.x branch of the CDN module requires PHP >=8.1, rather than core's >=7.4.
-  CORE_PREVIOUS_PHP_MIN: '8.1'
-  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 11).
+  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 12).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 
 # This module wants to strictly comply with Drupal's coding standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- drop support of Drupal 9.x
 
 ## [4.0.3] - 2025-04-23
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.1 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.4 drupal
     (get a coffee, this will take some time...)
     docker compose up --build -d drupal
     docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=10.1
+ARG BASE_IMAGE_TAG=10.4
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 # Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ but those are some of the obvious uses of Template Whisperer.
 
 ## Which version should I use?
 
-Template Whisperer is available for Drupal 8, Drupal 9, Drupal 10 and Drupal 11 (dev)!
+Template Whisperer is available for Drupal 8, Drupal 9, Drupal 10 and Drupal 11 !
 
 | Drupal Core | Template Whisperer |
 |:-----------:|:------------------:|
@@ -77,7 +77,7 @@ Template Whisperer is available for Drupal 8, Drupal 9, Drupal 10 and Drupal 11 
 |    8.9.x    |        3.0         |
 |     9.x     |        3.x         |
 |    10.x     |       4.0.x        |
-|  11.x-dev   |       4.0.x        |
+|    11.x     |       4.0.x        |
 
 ## Dependencies
 

--- a/template_whisperer.info.yml
+++ b/template_whisperer.info.yml
@@ -1,7 +1,7 @@
 name: Template Whisperer
 type: module
 description: Provides a formalized way to declare and suggest page templates.
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 package: Fields types
 
 dependencies:


### PR DESCRIPTION
### 💬 Description
drop support of Drupal 9.x

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
