### PR TITLE
add official support of drupal 11.2 && add coverage of Drupal 10.3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1', '11.2']
         module: ['template_whisperer']
         experimental: [ false ]
         include:
-          - drupal_version: '11.2'
+          - drupal_version: '11.3'
             module: 'template_whisperer'
             experimental: true
 
@@ -43,11 +43,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1', '11.2']
         module: ['template_whisperer']
         experimental: [ false ]
         include:
-          - drupal_version: '11.2'
+          - drupal_version: '11.3'
             module: 'template_whisperer'
             experimental: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 11.2
+- add coverage of Drupal 11.3.x
 
 ## [4.0.4] - 2025-05-15
 ### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.4 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=11.2 drupal
     (get a coffee, this will take some time...)
     docker compose up --build -d drupal
     docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=10.4
+ARG BASE_IMAGE_TAG=11.2
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 # Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.


### PR DESCRIPTION
### 💬 Description
add official support of drupal 11.2 && add coverage of Drupal 10.3.x

### 🎟️ Issue(s)

### 🔢 To Review
1. 
2. 

- [ ] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
