### PR TITLE
guard against null original entity before calling hasTranslation()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.6']
+        drupal_version: ['11.3']
         module: ['template_whisperer']
 
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,3 +44,17 @@ variables:
 # This module wants to strictly comply with Drupal's coding standards.
 phpcs:
   allow_failure: false
+
+# PHPStan analysis against the previous major (Drupal 10.x) requires stripping
+# PHP attributes that reference PHPUnit\Framework\Attributes classes unavailable
+# in older PHPUnit versions bundled with Drupal 10.
+# See https://www.drupal.org/project/verify_email/issues/3546315
+
+phpstan (previous major):
+  before_script:
+    - find $DRUPAL_PROJECT_FOLDER/tests/src -name '*.php' -exec sed -i '/^[[:space:]]*#\[Group(/d' {} +
+    - find $DRUPAL_PROJECT_FOLDER/tests/src -name '*.php' -exec sed -i '/^[[:space:]]*#\[RunTestsInSeparateProcesses/d' {} +
+    - find $DRUPAL_PROJECT_FOLDER/tests/src -name '*.php' -exec sed -i '/^[[:space:]]*#\[CoversClass(/d' {} +
+    - find $DRUPAL_PROJECT_FOLDER/tests/src -name '*.php' -exec sed -i '/^[[:space:]]*#\[CoversMethod(/d' {} +
+    - find $DRUPAL_PROJECT_FOLDER/tests/src -name '*.php' -exec sed -i '/^[[:space:]]*#\[CoversFunction(/d' {} +
+    - find $DRUPAL_PROJECT_FOLDER/tests/src -name '*.php' -exec sed -i '/^[[:space:]]*#\[DataProvider(/d' {} +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - remove deprecated setAccessible() calls deprecated since PHP 8.5
 - annotate unsafe new static() usages per Drupal PHPStan guidelines
+- add PHPUnit 10 PHP attributes (`#[Group]`, `#[RunTestsInSeparateProcesses]`, `#[CoversClass]`, `#[CoversMethod]`, `#[CoversFunction]`, `#[DataProvider]`) to all test classes
 
 ### Fixed
 - guard against null original entity before calling hasTranslation()
+- add `phpstan (previous major)` CI job that strips PHPUnit attribute lines before analysis against Drupal 10.
 
 ## [4.0.6] - 2026-01-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - remove deprecated setAccessible() calls deprecated since PHP 8.5
+- annotate unsafe new static() usages per Drupal PHPStan guidelines
 
 ### Fixed
 - guard against null original entity before calling hasTranslation()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - remove deprecated setAccessible() calls deprecated since PHP 8.5
 
+### Fixed
+- guard against null original entity before calling hasTranslation()
+
 ## [4.0.6] - 2026-01-26
 ### Added
 - add official support of drupal 10.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove deprecated setAccessible() calls deprecated since PHP 8.5
 - annotate unsafe new static() usages per Drupal PHPStan guidelines
 - add PHPUnit 10 PHP attributes (`#[Group]`, `#[RunTestsInSeparateProcesses]`, `#[CoversClass]`, `#[CoversMethod]`, `#[CoversFunction]`, `#[DataProvider]`) to all test classes
+- run upgrade-status against Drupal 11.3
 
 ### Fixed
 - guard against null original entity before calling hasTranslation()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker compose build --pull --build-arg BASE_IMAGE_TAG=11.2 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=11.3 drupal
     (get a coffee, this will take some time...)
     docker compose up --build -d drupal
     docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=11.2
+ARG BASE_IMAGE_TAG=11.3
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 # Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,3 @@ includes:
 parameters:
   level: 1
   reportUnmatchedIgnoredErrors: false
-  ignoreErrors:
-    # new static() is a best practice in Drupal, so we cannot fix that.
-    - "#^Unsafe usage of new static#"

--- a/src/Controller/AdminSuggestionController.php
+++ b/src/Controller/AdminSuggestionController.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Listing of Template Whisperer suggestions.
  */
-class AdminSuggestionController extends ControllerBase {
+final class AdminSuggestionController extends ControllerBase {
 
   /**
    * Retrieves the entity type manager.
@@ -58,7 +58,7 @@ class AdminSuggestionController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     // Instantiates this form class.
-    return new static(
+    return new self(
       // Load the service required to construct this class.
       $container->get('entity_type.manager'),
       $container->get('template_whisperer.suggestion.usage'),

--- a/src/Form/TemplateWhispererSuggestionDeleteForm.php
+++ b/src/Form/TemplateWhispererSuggestionDeleteForm.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Provides a form for Template Whisperer Suggestion deletion.
  */
-class TemplateWhispererSuggestionDeleteForm extends EntityConfirmFormBase {
+final class TemplateWhispererSuggestionDeleteForm extends EntityConfirmFormBase {
 
   /**
    * Template Whisperer Suggestion Usage.
@@ -32,7 +32,7 @@ class TemplateWhispererSuggestionDeleteForm extends EntityConfirmFormBase {
    */
   public static function create(ContainerInterface $container) {
     // Instantiates this form class.
-    return new static(
+    return new self(
     // Load the service required to construct this class.
     $container->get('template_whisperer.suggestion.usage')
     );

--- a/src/Form/TemplateWhispererSuggestionForm.php
+++ b/src/Form/TemplateWhispererSuggestionForm.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @ingroup template_whisperer
  */
-class TemplateWhispererSuggestionForm extends EntityForm {
+final class TemplateWhispererSuggestionForm extends EntityForm {
 
   /**
    * Template Whisperer Manager.
@@ -33,7 +33,7 @@ class TemplateWhispererSuggestionForm extends EntityForm {
    */
   public static function create(ContainerInterface $container) {
     // Instantiates this form class.
-    return new static(
+    return new self(
     // Load the service required to construct this class.
     $container->get('plugin.manager.template_whisperer')
     );

--- a/src/Plugin/Condition/TemplateWhisperer.php
+++ b/src/Plugin/Condition/TemplateWhisperer.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class TemplateWhisperer extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+final class TemplateWhisperer extends ConditionPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * The Template Manager.
@@ -40,7 +40,7 @@ class TemplateWhisperer extends ConditionPluginBase implements ContainerFactoryP
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
+    return new self(
       $configuration,
       $plugin_id,
       $plugin_definition,

--- a/src/Plugin/Field/FieldType/TemplateWhispererFieldItem.php
+++ b/src/Plugin/Field/FieldType/TemplateWhispererFieldItem.php
@@ -147,7 +147,7 @@ class TemplateWhispererFieldItem extends FieldItemBase {
       $original_ids = [];
       $langcode = $this->getLangcode();
       $original = $entity->original;
-      if ($original->hasTranslation($langcode)) {
+      if ($original && $original->hasTranslation($langcode)) {
         $original_items = $original->getTranslation($langcode)->{$field_name};
         foreach ($original_items as $item) {
           $original_ids[] = $item->target_id;

--- a/src/Plugin/Field/FieldWidget/TemplateWhispererWidget.php
+++ b/src/Plugin/Field/FieldWidget/TemplateWhispererWidget.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class TemplateWhispererWidget extends WidgetBase implements ContainerFactoryPluginInterface {
+final class TemplateWhispererWidget extends WidgetBase implements ContainerFactoryPluginInterface {
 
   /**
    * Template Whisperer Manager.
@@ -42,7 +42,7 @@ class TemplateWhispererWidget extends WidgetBase implements ContainerFactoryPlug
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
+    return new self(
     $plugin_id,
     $plugin_definition,
     $configuration['field_definition'],

--- a/src/TemplateWhispererSuggestionListBuilder.php
+++ b/src/TemplateWhispererSuggestionListBuilder.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @see \Drupal\template_whisperer\Entity\TemplateWhisperer
  */
-class TemplateWhispererSuggestionListBuilder extends ConfigEntityListBuilder {
+final class TemplateWhispererSuggestionListBuilder extends ConfigEntityListBuilder {
 
   /**
    * The url generator service.
@@ -52,7 +52,7 @@ class TemplateWhispererSuggestionListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
-    return new static(
+    return new self(
       $entity_type,
       $container->get('entity_type.manager')->getStorage($entity_type->id()),
       $container->get('url_generator'),

--- a/template_whisperer.info.yml
+++ b/template_whisperer.info.yml
@@ -1,7 +1,7 @@
 name: Template Whisperer
 type: module
 description: Provides a formalized way to declare and suggest page templates.
-core_version_requirement: ^10.5 || ^11
+core_version_requirement: ^10.5 || ^11 || ^12
 package: Fields types
 
 dependencies:

--- a/tests/src/Functional/ConditionalBlockTest.php
+++ b/tests/src/Functional/ConditionalBlockTest.php
@@ -3,15 +3,20 @@
 namespace Drupal\Tests\template_whisperer\Functional;
 
 use Drupal\block\BlockInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Ensures that Template Whisperer suggestions conditions' block work correctly.
  *
- * @group template_whisperer_functional_block
  * @group template_whisperer_functional
- * @group template_whisperer_ui
  * @group template_whisperer
  */
+#[Group('template_whisperer_functional_block')]
+#[Group('template_whisperer_functional')]
+#[Group('template_whisperer_ui')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class ConditionalBlockTest extends TemplateWhispererTestBase {
 
   /**

--- a/tests/src/Functional/HelpPageTest.php
+++ b/tests/src/Functional/HelpPageTest.php
@@ -3,6 +3,8 @@
 namespace Drupal\Tests\template_whisperer\Functional;
 
 use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Ensure the Template Whisperer help page works.
@@ -10,11 +12,14 @@ use Drupal\Tests\BrowserTestBase;
  * Verifies that the module help page from hook_help() exists and can be
  * displayed.
  *
- * @group template_whisperer_functional_help
  * @group template_whisperer_functional
- * @group template_whisperer_ui
  * @group template_whisperer
  */
+#[Group('template_whisperer_functional_help')]
+#[Group('template_whisperer_functional')]
+#[Group('template_whisperer_ui')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class HelpPageTest extends BrowserTestBase {
 
   /**

--- a/tests/src/Functional/SuggestionTokenReplaceTest.php
+++ b/tests/src/Functional/SuggestionTokenReplaceTest.php
@@ -2,16 +2,22 @@
 
 namespace Drupal\Tests\template_whisperer\Functional;
 
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
 /**
  * Check suggestion tokens replacement.
  *
- * @covers ::template_whisperer_token_info
- * @covers ::template_whisperer_tokens
- *
- * @group template_whisperer_functional_token
  * @group template_whisperer_functional
  * @group template_whisperer
  */
+#[CoversFunction('template_whisperer_token_info')]
+#[CoversFunction('template_whisperer_tokens')]
+#[Group('template_whisperer_functional_token')]
+#[Group('template_whisperer_functional')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class SuggestionTokenReplaceTest extends TemplateWhispererTestBase {
 
   /**

--- a/tests/src/Functional/UiFieldTest.php
+++ b/tests/src/Functional/UiFieldTest.php
@@ -2,14 +2,20 @@
 
 namespace Drupal\Tests\template_whisperer\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
 /**
  * Tests event info pages and links.
  *
- * @group template_whisperer_functional_field
  * @group template_whisperer_functional
- * @group template_whisperer_ui
  * @group template_whisperer
  */
+#[Group('template_whisperer_functional_field')]
+#[Group('template_whisperer_functional')]
+#[Group('template_whisperer_ui')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class UiFieldTest extends TemplateWhispererTestBase {
 
   /**

--- a/tests/src/Functional/UiPageTest.php
+++ b/tests/src/Functional/UiPageTest.php
@@ -2,14 +2,20 @@
 
 namespace Drupal\Tests\template_whisperer\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
 /**
  * Tests event info pages and links.
  *
- * @group template_whisperer_functional_page
  * @group template_whisperer_functional
- * @group template_whisperer_ui
  * @group template_whisperer
  */
+#[Group('template_whisperer_functional_page')]
+#[Group('template_whisperer_functional')]
+#[Group('template_whisperer_ui')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class UiPageTest extends TemplateWhispererTestBase {
 
   /**

--- a/tests/src/Functional/WidgetFormElementTest.php
+++ b/tests/src/Functional/WidgetFormElementTest.php
@@ -3,6 +3,11 @@
 namespace Drupal\Tests\template_whisperer\Functional;
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\template_whisperer\Plugin\Field\FieldWidget\TemplateWhispererWidget;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Assert fields placed in the advanced tabs.
@@ -11,13 +16,16 @@ use Drupal\Core\Entity\Entity\EntityFormDisplay;
  * when possible. Otherwise will stay in place.
  * Eg. when used on taxonomy form or when embeed into an inline-edit-form.
  *
- * @coversDefaultClass \Drupal\template_whisperer\Plugin\Field\FieldWidget\TemplateWhispererWidget
- *
- * @group template_whisperer_functional_field
  * @group template_whisperer_functional
- * @group template_whisperer_ui
  * @group template_whisperer
  */
+#[CoversClass(TemplateWhispererWidget::class)]
+#[CoversMethod(TemplateWhispererWidget::class, 'formElement')]
+#[Group('template_whisperer_functional_field')]
+#[Group('template_whisperer_functional')]
+#[Group('template_whisperer_ui')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class WidgetFormElementTest extends TemplateWhispererTestBase {
 
   /**
@@ -148,7 +156,7 @@ class WidgetFormElementTest extends TemplateWhispererTestBase {
   }
 
   /**
-   * @covers ::formElement
+   * Tests that the field is moved to the Advanced group on node forms.
    */
   public function testMoveFieldToAdvancedGroup() {
     // Access the node edit page.
@@ -159,7 +167,7 @@ class WidgetFormElementTest extends TemplateWhispererTestBase {
   }
 
   /**
-   * @covers ::formElement
+   * Tests that the field stays in place when advanced tabs are unavailable.
    */
   public function testWhenNotPossibleStayInPlace() {
     // Access the taxonomy term edit page.

--- a/tests/src/Kernel/FieldTemplateWhispererTest.php
+++ b/tests/src/Kernel/FieldTemplateWhispererTest.php
@@ -6,6 +6,9 @@ use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Tests\field\Kernel\FieldKernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the Template Whisperer field type.
@@ -16,10 +19,12 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
  *
  * @see \Drupal\KernelTests\KernelTestBase
  *
- * @group template_whisperer_kernel_page
- * @group template_whisperer_kernel
  * @group template_whisperer
  */
+#[Group('template_whisperer_kernel_page')]
+#[Group('template_whisperer_kernel')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class FieldTemplateWhispererTest extends FieldKernelTestBase {
 
   use UserCreationTrait;
@@ -129,6 +134,7 @@ class FieldTemplateWhispererTest extends FieldKernelTestBase {
    *
    * @dataProvider providerTestTemaplteWhispererFieldAccess
    */
+  #[DataProvider('providerTestTemaplteWhispererFieldAccess')]
   public function testTemaplteWhispererFieldAccess($permissions, $scenarios) {
     // Create and entity with a template whisperer value.
     $type_manager = $this->container->get('entity_type.manager');

--- a/tests/src/Kernel/TemplateWhispererManagerTest.php
+++ b/tests/src/Kernel/TemplateWhispererManagerTest.php
@@ -3,14 +3,23 @@
 namespace Drupal\Tests\template_whisperer\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\template_whisperer\TemplateWhispererManager;
 use Drupal\Tests\template_whisperer\Traits\InvokeMethodTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the Template Whisperer Manager.
  *
- * @group template_whisperer_kernel
  * @group template_whisperer
  */
+#[CoversClass(TemplateWhispererManager::class)]
+#[CoversMethod(TemplateWhispererManager::class, 'getFieldSuggestions')]
+#[Group('template_whisperer_kernel')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class TemplateWhispererManagerTest extends KernelTestBase {
   use InvokeMethodTrait;
 
@@ -94,7 +103,7 @@ class TemplateWhispererManagerTest extends KernelTestBase {
   }
 
   /**
-   * @covers \Drupal\template_whisperer\TemplateWhispererManager::getFieldSuggestions
+   * Tests getFieldSuggestions() returns the correct suggestion for an entity.
    */
   public function testGetFieldSuggestions() {
     /** @var \Drupal\template_whisperer\TemplateWhispererManager $tw_manager */

--- a/tests/src/Kernel/TwigExtensionTest.php
+++ b/tests/src/Kernel/TwigExtensionTest.php
@@ -4,13 +4,22 @@ namespace Drupal\Tests\template_whisperer\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\template_whisperer\Entity\TemplateWhispererSuggestionEntityInterface;
+use Drupal\template_whisperer\TwigExtension\TwigExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the Template Whisperer twig extensions.
  *
- * @group template_whisperer_twig
  * @group template_whisperer
  */
+#[CoversClass(TwigExtension::class)]
+#[CoversMethod(TwigExtension::class, 'getEntitiesFromSuggestion')]
+#[Group('template_whisperer_twig')]
+#[Group('template_whisperer')]
+#[RunTestsInSeparateProcesses]
 class TwigExtensionTest extends KernelTestBase {
 
   /**
@@ -98,7 +107,7 @@ class TwigExtensionTest extends KernelTestBase {
   }
 
   /**
-   * @covers Drupal\template_whisperer\TwigExtension\TwigExtension::getEntitiesFromSuggestion
+   * Tests getEntitiesFromSuggestion() may returns one entity by suggestion.
    */
   public function testsGetOneEntityFromSuggestion() {
     /** @var \Drupal\template_whisperer\TwigExtension\TwigExtension $extension */
@@ -111,7 +120,7 @@ class TwigExtensionTest extends KernelTestBase {
   }
 
   /**
-   * @covers Drupal\template_whisperer\TwigExtension\TwigExtension::getEntitiesFromSuggestion
+   * Tests getEntitiesFromSuggestion() returns multiple entities by suggestion.
    */
   public function testsGetEntitiesFromSuggestion() {
     /** @var \Drupal\template_whisperer\TwigExtension\TwigExtension $extension */
@@ -123,7 +132,7 @@ class TwigExtensionTest extends KernelTestBase {
   }
 
   /**
-   * @covers Drupal\template_whisperer\TwigExtension\TwigExtension::getEntitiesFromSuggestion
+   * Tests getEntitiesFromSuggestion() returns empty for an unknown suggestion.
    */
   public function testsGetNoneEntitiesBySuggestion() {
     /** @var \Drupal\template_whisperer\TwigExtension\TwigExtension $extension */


### PR DESCRIPTION
### 💬 Description
guard against null original entity before calling hasTranslation()

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
