### PR TITLE
fix(test): create the Article content type in UiFieldTest, removed from the standard profile in Drupal 11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix(test): create the Article content type in UiFieldTest, removed from the standard profile in Drupal 11.4
 
 ## [4.1.1] - 2026-07-02
 ### Added

--- a/tests/src/Functional/UiFieldTest.php
+++ b/tests/src/Functional/UiFieldTest.php
@@ -74,6 +74,13 @@ class UiFieldTest extends TemplateWhispererTestBase {
       ]);
     $this->template->save();
 
+    // Since Drupal 11.4 the standard profile does not ship the Article content
+    // type anymore, it has to be created by the test itself.
+    // @see https://www.drupal.org/project/drupal/issues/3587118
+    if (!$this->container->get('entity_type.manager')->getStorage('node_type')->load('article')) {
+      $this->drupalCreateContentType(['type' => 'article', 'name' => 'Article']);
+    }
+
     // Create an article content type that we will use for testing.
     $this->article = $this->drupalCreateNode(['type' => 'article']);
   }


### PR DESCRIPTION
### 💬 Description
fix(test): create the Article content type in UiFieldTest, removed from the standard profile in Drupal 11.4

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)

